### PR TITLE
[WIP] Fix header Python Italia logo not visible

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -9,6 +9,10 @@ const HeaderSection = Section.extend`
   background-color: #18a8e8;
   color: white;
 
+  > div {
+      height: auto;
+  }
+
   svg {
     display: block;
     width: 80%;


### PR DESCRIPTION
Looks like iOS safari is unable to calculate the correct height
when the children is an SVG. We might also remove the wrapper div
of the logo as it seems unnecessary.